### PR TITLE
Fix HTTP backend sample

### DIFF
--- a/samples/03-use-http-backend/http-test/settings.gradle
+++ b/samples/03-use-http-backend/http-test/settings.gradle
@@ -1,10 +1,10 @@
 
 buildCache {
   local {
-       enabled = false
+    enabled = false
   }
   remote(HttpBuildCache) {
-  	url = System.getProperty("cache.url", "http://localhost:8885/")
-       push = enabled
+    url = System.getProperty("cache.url", "http://localhost:8885/")
+    push = true
   }
 }

--- a/samples/03-use-http-backend/http-test/settings.gradle
+++ b/samples/03-use-http-backend/http-test/settings.gradle
@@ -1,10 +1,10 @@
 
 buildCache {
   local {
-    enabled = false
+      enabled = false
   }
   remote(HttpBuildCache) {
-    url = System.getProperty("cache.url", "http://localhost:8885/")
-    push = true
+      url = System.getProperty("cache.url", "http://localhost:8885/")
+      push = true
   }
 }

--- a/samples/03-use-http-backend/http-test/settings.gradle
+++ b/samples/03-use-http-backend/http-test/settings.gradle
@@ -1,6 +1,10 @@
 
 buildCache {
+  local {
+       enabled = false
+  }
   remote(HttpBuildCache) {
   	url = System.getProperty("cache.url", "http://localhost:8885/")
+       push = enabled
   }
 }


### PR DESCRIPTION
The sample doesn't really work before.
We have used the local cache. Which means we don't demonstraded the remote http backend as cache.

Disabling the local cache and enabling the remote cache to push fixed that.

**How to reproduce?**
Checkout the **current**  sample and follow the README.
After running http-test, check the directory of the docker image:
```
$ docker exec -it gradle-task-cache bash
$ cd /usr/share/nginx/task-cache
$ ls
```
The output: Nothing. The dir is empty.
Check the local cache at `~/.gradle/caches/3.6-20170314000035+0000/build-cache/`. There is the cached output (which is totally fine. But we don't want to demonstrate the local cache rather than the http backend cache 😉).

Checkout this PR:
Do the same thing I've described above.
You will notice that the `task-cache` is not empty anymore and this cache will be used when you ran http-test twice.